### PR TITLE
Fix CORS for production by adding proxy to preview server

### DIFF
--- a/src/services/mvsepAPI.js
+++ b/src/services/mvsepAPI.js
@@ -4,17 +4,17 @@
  * API Documentation: https://mvsep.com/api
  */
 
-// Use proxy in development to avoid CORS issues
-// In development: /api/mvsep/* -> https://mvsep.com/* (via Vite proxy)
-// In production: You may need to configure CORS with MVSep or use a backend proxy
-const API_BASE_URL = import.meta.env.DEV ? '/api/mvsep' : 'https://mvsep.com'
+// Use Vite proxy to avoid CORS issues
+// The proxy is configured in vite.config.js for both dev and preview servers
+// /api/mvsep/* -> https://mvsep.com/* (via Vite proxy)
+const API_BASE_URL = '/api/mvsep'
 const STORAGE_KEY = 'mvsep_api_token'
 
 // Debug: Log API configuration
 console.log('🔧 MVSep API Configuration:', {
-  isDev: import.meta.env.DEV,
   apiBaseUrl: API_BASE_URL,
-  mode: import.meta.env.MODE
+  mode: import.meta.env.MODE,
+  isDev: import.meta.env.DEV
 })
 
 /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,7 +23,15 @@ export default defineConfig({
       '.onrender.com',
       'localhost',
       '127.0.0.1'
-    ]
+    ],
+    proxy: {
+      '/api/mvsep': {
+        target: 'https://mvsep.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/mvsep/, ''),
+        secure: true
+      }
+    }
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
The app was failing on Render.com because:
1. Render runs in production mode (import.meta.env.DEV = false)
2. The proxy was only configured for dev server, not preview server
3. API calls went directly to https://mvsep.com causing CORS errors
