### PR TITLE
Refactor audio engine to clip-based playback and rendering

### DIFF
--- a/src/audio/AudioEngine.js
+++ b/src/audio/AudioEngine.js
@@ -186,16 +186,28 @@ class AudioEngine {
       const clipEnd = clip.startTime + clip.duration;
       if (clipEnd <= startOffset) continue; // clip already passed
 
-      // When startOffset is inside the clip, start the buffer partway through;
-      // otherwise wait until the clip's startTime.
-      const bufferOffset = Math.max(0, startOffset - clip.startTime);
+      const sampleRate = clip.buffer.sampleRate;
+      // A split clip references a window of its parent buffer via
+      // bufferOffset/bufferLength (in samples). Translate that to the
+      // (offset, duration) pair expected by source.start().
+      const windowOffsetSec = (clip.bufferOffset || 0) / sampleRate;
+      const windowLengthSec = clip.bufferLength != null
+        ? clip.bufferLength / sampleRate
+        : clip.duration;
+
+      // When startOffset is inside the clip, start the buffer partway through.
+      const clipRelativeSkip = Math.max(0, startOffset - clip.startTime);
+      const playOffsetSec = windowOffsetSec + clipRelativeSkip;
+      const playDurationSec = Math.max(0, windowLengthSec - clipRelativeSkip);
+      if (playDurationSec <= 0) continue;
+
       const when = contextStartTime + Math.max(0, clip.startTime - startOffset);
 
       const source = this.audioContext.createBufferSource();
       source.buffer = clip.buffer;
       source.connect(track.gainNode);
       try {
-        source.start(when, bufferOffset);
+        source.start(when, playOffsetSec, playDurationSec);
       } catch (e) {
         console.warn('Failed to start clip source:', e);
         continue;
@@ -379,7 +391,13 @@ class AudioEngine {
         const source = offlineCtx.createBufferSource();
         source.buffer = clip.buffer;
         source.connect(gain);
-        source.start(clip.startTime);
+
+        const sr = clip.buffer.sampleRate;
+        const windowOffsetSec = (clip.bufferOffset || 0) / sr;
+        const windowLengthSec = clip.bufferLength != null
+          ? clip.bufferLength / sr
+          : clip.duration;
+        source.start(clip.startTime, windowOffsetSec, windowLengthSec);
       }
     }
 

--- a/src/audio/AudioEngine.js
+++ b/src/audio/AudioEngine.js
@@ -8,6 +8,8 @@ class AudioEngine {
     this.audioContext = null;
     this.masterGain = null;
     this.tracks = new Map();
+    // Per-track list of currently-scheduled buffer sources, so stop() can cancel them.
+    this.activeSources = new Map();
     this.isPlaying = false;
     this.currentTime = 0;
     this.sampleRate = 44100;
@@ -140,6 +142,15 @@ class AudioEngine {
       track.source = null;
     }
 
+    // Cancel any scheduled clip sources for this track
+    const sources = this.activeSources.get(trackId);
+    if (sources) {
+      for (const source of sources) {
+        try { source.stop(); source.disconnect(); } catch (e) {}
+      }
+      this.activeSources.delete(trackId);
+    }
+
     // Disconnect audio nodes
     try {
       track.gainNode.disconnect();
@@ -154,58 +165,93 @@ class AudioEngine {
   }
 
   /**
-   * Play a specific track
+   * Schedule playback of the given clips on a track.
+   * Each clip is scheduled as its own BufferSource at its startTime, which
+   * avoids the memory/CPU cost of pre-mixing clips into a single track buffer.
+   *
+   * @param {string} trackId
+   * @param {Array} clips - [{ buffer, startTime, duration }, ...]
+   * @param {number} startOffset - playback position in seconds within the project
+   * @param {number} contextStartTime - audioContext time to anchor scheduling at
+   */
+  playTrackClips(trackId, clips, startOffset, contextStartTime) {
+    const track = this.tracks.get(trackId);
+    if (!track || track.muted) return;
+
+    const sources = this.activeSources.get(trackId) || [];
+
+    for (const clip of clips) {
+      if (!clip.buffer) continue;
+
+      const clipEnd = clip.startTime + clip.duration;
+      if (clipEnd <= startOffset) continue; // clip already passed
+
+      // When startOffset is inside the clip, start the buffer partway through;
+      // otherwise wait until the clip's startTime.
+      const bufferOffset = Math.max(0, startOffset - clip.startTime);
+      const when = contextStartTime + Math.max(0, clip.startTime - startOffset);
+
+      const source = this.audioContext.createBufferSource();
+      source.buffer = clip.buffer;
+      source.connect(track.gainNode);
+      try {
+        source.start(when, bufferOffset);
+      } catch (e) {
+        console.warn('Failed to start clip source:', e);
+        continue;
+      }
+      sources.push(source);
+    }
+
+    this.activeSources.set(trackId, sources);
+  }
+
+  /**
+   * Legacy single-buffer track playback (kept for any non-clip callers).
    */
   playTrack(trackId, startTime = 0) {
     const track = this.tracks.get(trackId);
     if (!track || !track.buffer) return;
 
-    // Stop existing source if playing
     if (track.source) {
-      track.source.stop();
-      track.source.disconnect();
+      try { track.source.stop(); track.source.disconnect(); } catch (e) {}
     }
 
-    // Create new buffer source
     track.source = this.audioContext.createBufferSource();
     track.source.buffer = track.buffer;
     track.source.connect(track.gainNode);
-
-    // Start playback
     track.source.start(0, startTime);
   }
 
   /**
-   * Play all tracks
+   * @deprecated Prefer audioStore.play() which calls playTrackClips per track.
+   * Kept as a no-op guard so old calls don't crash.
    */
   play(startTime = 0) {
     this.resume();
     this.currentTime = startTime;
-
-    for (const [trackId, track] of this.tracks) {
-      if (!track.muted && track.buffer) {
-        this.playTrack(trackId, startTime);
-      }
-    }
-
     this.isPlaying = true;
   }
 
   /**
-   * Stop playback
+   * Stop playback - cancels every scheduled source.
    */
   stop() {
-    for (const [trackId, track] of this.tracks) {
-      if (track.source) {
-        try {
-          track.source.stop();
-          track.source.disconnect();
-          track.source = null;
-        } catch (e) {
-          // Source may already be stopped
-        }
+    for (const [, sources] of this.activeSources) {
+      for (const source of sources) {
+        try { source.stop(); source.disconnect(); } catch (e) { /* already stopped */ }
       }
     }
+    this.activeSources.clear();
+
+    // Also cancel any legacy single-source tracks
+    for (const [, track] of this.tracks) {
+      if (track.source) {
+        try { track.source.stop(); track.source.disconnect(); } catch (e) {}
+        track.source = null;
+      }
+    }
+
     this.isPlaying = false;
     this.currentTime = 0;
   }
@@ -293,15 +339,64 @@ class AudioEngine {
   }
 
   /**
-   * Get mixed buffer from all tracks (for export)
+   * Render clips from the given tracks into a single AudioBuffer using an
+   * OfflineAudioContext. Only used for export - during editing there is no
+   * pre-mixed track buffer.
+   *
+   * @param {Array} trackSpecs - [{ id, clips, volume, pan, muted }, ...]
+   * @returns {Promise<AudioBuffer|null>}
+   */
+  async renderTracksOffline(trackSpecs, masterVolume = 1) {
+    const sampleRate = this.sampleRate;
+
+    let totalDuration = 0;
+    for (const t of trackSpecs) {
+      if (t.muted) continue;
+      for (const clip of t.clips) {
+        totalDuration = Math.max(totalDuration, clip.startTime + clip.duration);
+      }
+    }
+    if (totalDuration === 0) return null;
+
+    const length = Math.ceil(totalDuration * sampleRate);
+    const offlineCtx = new OfflineAudioContext(2, length, sampleRate);
+
+    const master = offlineCtx.createGain();
+    master.gain.value = masterVolume;
+    master.connect(offlineCtx.destination);
+
+    for (const t of trackSpecs) {
+      if (t.muted) continue;
+      const gain = offlineCtx.createGain();
+      gain.gain.value = t.volume ?? 1;
+      const pan = offlineCtx.createStereoPanner();
+      pan.pan.value = t.pan ?? 0;
+      gain.connect(pan);
+      pan.connect(master);
+
+      for (const clip of t.clips) {
+        if (!clip.buffer) continue;
+        const source = offlineCtx.createBufferSource();
+        source.buffer = clip.buffer;
+        source.connect(gain);
+        source.start(clip.startTime);
+      }
+    }
+
+    return await offlineCtx.startRendering();
+  }
+
+  /**
+   * @deprecated Legacy sync mix from pre-mixed track.buffers. Kept as a
+   * compatibility shim for callers that still read track.buffer directly; the
+   * clip-based path uses renderTracksOffline.
    */
   getMixedBuffer() {
-    // Find all non-muted tracks with buffers
     const activeTracks = [];
     let maxDuration = 0;
     let maxChannels = 2;
 
-    for (const [trackId, track] of this.tracks) {
+    for (const [, track] of this.tracks) {
       if (!track.muted && track.buffer) {
         activeTracks.push(track);
         maxDuration = Math.max(maxDuration, track.buffer.duration);
@@ -311,28 +406,19 @@ class AudioEngine {
 
     if (activeTracks.length === 0) return null;
 
-    // Create output buffer
     const sampleRate = this.sampleRate;
     const length = Math.ceil(maxDuration * sampleRate);
     const mixedBuffer = this.audioContext.createBuffer(maxChannels, length, sampleRate);
+    for (let ch = 0; ch < maxChannels; ch++) mixedBuffer.getChannelData(ch).fill(0);
 
-    // Initialize with silence
-    for (let ch = 0; ch < maxChannels; ch++) {
-      mixedBuffer.getChannelData(ch).fill(0);
-    }
-
-    // Mix all tracks
     for (const track of activeTracks) {
       const buffer = track.buffer;
       const volume = track.volume;
-
       for (let ch = 0; ch < maxChannels; ch++) {
         const mixedData = mixedBuffer.getChannelData(ch);
         const sourceChannelIndex = Math.min(ch, buffer.numberOfChannels - 1);
         const sourceData = buffer.getChannelData(sourceChannelIndex);
-
         for (let i = 0; i < Math.min(sourceData.length, mixedData.length); i++) {
-          // Mix with volume applied
           mixedData[i] = Math.max(-1, Math.min(1, mixedData[i] + sourceData[i] * volume));
         }
       }

--- a/src/audio/EffectsWorkerClient.js
+++ b/src/audio/EffectsWorkerClient.js
@@ -1,0 +1,75 @@
+/**
+ * Promise-based wrapper around the effects Web Worker.
+ * Manages a single worker instance, queues requests, and handles the
+ * transferable-buffer round trip.
+ */
+
+export class EffectsWorkerClient {
+  constructor() {
+    this.worker = null
+    this.nextId = 1
+    // id -> { resolve, reject, onProgress }
+    this.pending = new Map()
+  }
+
+  _ensureWorker() {
+    if (this.worker) return
+    this.worker = new Worker(
+      new URL('../workers/effectsWorker.js', import.meta.url),
+      { type: 'module' }
+    )
+    this.worker.onmessage = (event) => {
+      const { id, type } = event.data
+      const entry = this.pending.get(id)
+      if (!entry) return
+      if (type === 'progress') {
+        entry.onProgress?.(event.data.percent)
+      } else if (type === 'done') {
+        this.pending.delete(id)
+        entry.resolve(event.data.processedBuffers)
+      } else if (type === 'error') {
+        this.pending.delete(id)
+        entry.reject(new Error(event.data.error))
+      }
+    }
+    this.worker.onerror = (err) => {
+      for (const [, entry] of this.pending) entry.reject(err)
+      this.pending.clear()
+    }
+  }
+
+  /**
+   * Apply an effect to each channel of an AudioBuffer's data.
+   *
+   * @param {string} effectName
+   * @param {object} params - effect parameters
+   * @param {Float32Array[]} channelBuffers - one per channel; these are
+   *   transferred to the worker (zero-copy) so the caller must not use them
+   *   after this call returns.
+   * @param {number} sampleRate
+   * @param {(percent:number)=>void} [onProgress]
+   * @returns {Promise<Float32Array[]>} processed channels (newly allocated)
+   */
+  process(effectName, params, channelBuffers, sampleRate, onProgress) {
+    this._ensureWorker()
+    const id = this.nextId++
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject, onProgress })
+      const transfers = channelBuffers.map(c => c.buffer)
+      this.worker.postMessage(
+        { id, effectName, params, channelBuffers, sampleRate },
+        transfers
+      )
+    })
+  }
+
+  destroy() {
+    if (this.worker) {
+      this.worker.terminate()
+      this.worker = null
+    }
+    this.pending.clear()
+  }
+}
+
+export default EffectsWorkerClient

--- a/src/components/AudioClip.vue
+++ b/src/components/AudioClip.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useAudioStore } from '../stores/audioStore'
 
 const props = defineProps({
@@ -69,6 +69,10 @@ const emit = defineEmits(['delete'])
 const audioStore = useAudioStore()
 const clipElement = ref(null)
 const waveformCanvas = ref(null)
+// Virtualization: only draw/keep the canvas painted when the clip is near the
+// viewport. Initialised from mount via IntersectionObserver.
+const isVisible = ref(false)
+let intersectionObserver = null
 
 // Calculate clip position and width in pixels
 const clipPosition = computed(() => {
@@ -282,37 +286,69 @@ function onDragEnd(event) {
   // Clean up if needed
 }
 
-// Watch for changes that require redraw
+// Watch for changes that require redraw. Only trigger while the clip is
+// actually on-screen - off-screen clips repaint when they scroll back in.
 watch(
   () => props.clip,
   () => {
-    setTimeout(() => draw(), 0)
+    if (isVisible.value) setTimeout(() => draw(), 0)
   },
   { deep: true }
 )
 
-// Also watch project duration separately as it affects positioning
 watch(
   () => props.projectDuration,
   () => {
-    setTimeout(() => draw(), 0)
+    if (isVisible.value) setTimeout(() => draw(), 0)
   }
 )
 
-// Watch for view mode changes
 watch(
   () => audioStore.viewMode,
   () => {
-    setTimeout(() => draw(), 0)
+    if (isVisible.value) setTimeout(() => draw(), 0)
   }
 )
 
+function onResize() {
+  if (isVisible.value) setTimeout(() => draw(), 0)
+}
+
 onMounted(() => {
-  // Delay initial draw to ensure element is sized
-  setTimeout(() => draw(), 100)
-  // Redraw on window resize
-  window.addEventListener('resize', () => {
-    setTimeout(() => draw(), 0)
-  })
+  if (typeof IntersectionObserver !== 'undefined' && clipElement.value) {
+    intersectionObserver = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          if (!isVisible.value) {
+            isVisible.value = true
+            setTimeout(() => draw(), 0)
+          }
+        } else if (isVisible.value) {
+          isVisible.value = false
+          // Free GPU-backed canvas memory when scrolled far out of view.
+          const canvas = waveformCanvas.value
+          if (canvas) {
+            const ctx = canvas.getContext('2d')
+            ctx.clearRect(0, 0, canvas.width, canvas.height)
+          }
+        }
+      }
+    }, { rootMargin: '200px' })
+    intersectionObserver.observe(clipElement.value)
+  } else {
+    // Fallback for environments without IntersectionObserver.
+    isVisible.value = true
+    setTimeout(() => draw(), 100)
+  }
+
+  window.addEventListener('resize', onResize)
+})
+
+onBeforeUnmount(() => {
+  if (intersectionObserver) {
+    intersectionObserver.disconnect()
+    intersectionObserver = null
+  }
+  window.removeEventListener('resize', onResize)
 })
 </script>

--- a/src/components/EffectPanel.vue
+++ b/src/components/EffectPanel.vue
@@ -9,6 +9,17 @@
       </button>
     </div>
 
+    <!-- Progress bar shown while an effect is running in the worker -->
+    <div v-if="audioStore.effectProgress" class="px-4 py-2 border-b border-gray-700 bg-gray-900">
+      <div class="flex items-center justify-between text-xs text-gray-300 mb-1">
+        <span>Applying {{ audioStore.effectProgress.effectName }}...</span>
+        <span>{{ audioStore.effectProgress.percent }}%</span>
+      </div>
+      <div class="h-1 w-full bg-gray-700 rounded overflow-hidden">
+        <div class="h-full bg-blue-500 transition-all" :style="{ width: audioStore.effectProgress.percent + '%' }"></div>
+      </div>
+    </div>
+
     <div v-if="!selectedTrack" class="p-4 text-gray-400 text-sm">
       Select a track to apply effects
     </div>

--- a/src/components/Track.vue
+++ b/src/components/Track.vue
@@ -61,7 +61,7 @@
       <!-- Audio clips -->
       <AudioClip
         v-for="clip in track.clips"
-        :key="clip.id + '-' + (clip._lastModified || 0)"
+        :key="clip.id"
         :clip="clip"
         :track-id="track.id"
         :project-duration="audioStore.duration || 1"

--- a/src/components/Track.vue
+++ b/src/components/Track.vue
@@ -167,7 +167,6 @@ const props = defineProps({
 })
 
 const audioStore = useAudioStore()
-const waveformCanvas = ref(null)
 const timeMarkerCanvas = ref(null)
 const trackContainer = ref(null)
 const volume = ref(props.track.volume)
@@ -181,16 +180,17 @@ const contextMenuPosition = ref({ x: 0, y: 0 })
 const selectionStyle = computed(() => {
   if (!audioStore.selection || audioStore.selection.trackId !== props.track.id) return {}
 
-  if (!props.track.duration) return {}
+  const projectDuration = audioStore.duration || props.track.duration || 0
+  if (!projectDuration) return {}
 
-  const canvas = waveformCanvas.value
-  if (!canvas) return {}
+  const container = trackContainer.value
+  if (!container) return {}
 
-  const rect = canvas.getBoundingClientRect()
+  const width = container.clientWidth
   const { startTime, endTime } = audioStore.selection
 
-  const leftPx = (startTime / props.track.duration) * rect.width
-  const rightPx = (endTime / props.track.duration) * rect.width
+  const leftPx = (startTime / projectDuration) * width
+  const rightPx = (endTime / projectDuration) * width
 
   return {
     left: `${leftPx}px`,
@@ -199,18 +199,8 @@ const selectionStyle = computed(() => {
 })
 
 onMounted(() => {
-  drawWaveform()
   drawTimeMarkers()
-  // Redraw on window resize
-  window.addEventListener('resize', () => {
-    drawWaveform()
-    drawTimeMarkers()
-  })
-})
-
-watch(() => props.track.waveformData, () => {
-  drawWaveform()
-  drawTimeMarkers()
+  window.addEventListener('resize', drawTimeMarkers)
 })
 
 watch(() => props.track.duration, () => {
@@ -219,81 +209,8 @@ watch(() => props.track.duration, () => {
 
 watch(() => audioStore.duration, () => {
   // Redraw when project duration changes (longest track changes)
-  drawWaveform()
   drawTimeMarkers()
 })
-
-function drawWaveform() {
-  const canvas = waveformCanvas.value
-  if (!canvas) return
-
-  const ctx = canvas.getContext('2d')
-  const dpr = window.devicePixelRatio || 1
-  const rect = canvas.getBoundingClientRect()
-
-  // Set canvas size accounting for device pixel ratio
-  canvas.width = rect.width * dpr
-  canvas.height = rect.height * dpr
-
-  ctx.scale(dpr, dpr)
-
-  // Clear canvas
-  ctx.fillStyle = '#111827' // gray-900
-  ctx.fillRect(0, 0, rect.width, rect.height)
-
-  if (!props.track.waveformData || props.track.waveformData.length === 0) {
-    // Draw empty state
-    ctx.fillStyle = '#4b5563' // gray-600
-    ctx.font = '14px sans-serif'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-    ctx.fillText('No audio loaded', rect.width / 2, rect.height / 2)
-    return
-  }
-
-  // Scale waveform based on project duration (longest track)
-  const projectDuration = audioStore.duration || props.track.duration || 1
-  const trackDuration = props.track.duration || 0
-  const scaleFactor = trackDuration / projectDuration
-  const waveformWidth = rect.width * scaleFactor
-
-  // Draw waveform
-  const data = props.track.waveformData
-  const middle = rect.height / 2
-  const barWidth = waveformWidth / data.length
-  const color = props.track.color || '#3b82f6'
-
-  ctx.fillStyle = color
-
-  for (let i = 0; i < data.length; i++) {
-    const { min, max } = data[i]
-    const x = i * barWidth
-    const height = (max - min) * middle
-
-    ctx.fillRect(x, middle - (max * middle), Math.max(1, barWidth - 0.5), height)
-  }
-
-  // Draw center line across scaled waveform
-  ctx.strokeStyle = '#374151' // gray-700
-  ctx.lineWidth = 1
-  ctx.beginPath()
-  ctx.moveTo(0, middle)
-  ctx.lineTo(waveformWidth, middle)
-  ctx.stroke()
-
-  // Draw gray background for remainder
-  if (waveformWidth < rect.width) {
-    ctx.fillStyle = '#0f172a' // darker gray
-    ctx.fillRect(waveformWidth, 0, rect.width - waveformWidth, rect.height)
-
-    // Extend center line to end
-    ctx.strokeStyle = '#1f2937'
-    ctx.beginPath()
-    ctx.moveTo(waveformWidth, middle)
-    ctx.lineTo(rect.width, middle)
-    ctx.stroke()
-  }
-}
 
 function drawTimeMarkers() {
   const canvas = timeMarkerCanvas.value
@@ -376,12 +293,12 @@ let selectionStartTime = 0
 function startSelection(e) {
   // Only select on left click
   if (e.button !== 0) return
+  if (!trackContainer.value) return
 
-  const rect = waveformCanvas.value.getBoundingClientRect()
+  const rect = trackContainer.value.getBoundingClientRect()
   const x = e.clientX - rect.left
-  const duration = props.track.duration || 0
+  const duration = audioStore.duration || props.track.duration || 0
 
-  // Convert pixel to time
   selectionStartTime = (x / rect.width) * duration
 
   isSelecting.value = true
@@ -390,15 +307,13 @@ function startSelection(e) {
 
 function updateSelection(e) {
   if (!isSelecting.value) return
+  if (!trackContainer.value) return
 
-  const rect = waveformCanvas.value.getBoundingClientRect()
+  const rect = trackContainer.value.getBoundingClientRect()
   const x = Math.max(0, Math.min(e.clientX - rect.left, rect.width))
-  const duration = props.track.duration || 0
+  const duration = audioStore.duration || props.track.duration || 0
 
-  // Convert pixel to time
   const currentTime = (x / rect.width) * duration
-
-  // Update selection in store
   audioStore.setSelection(props.track.id, selectionStartTime, currentTime)
 }
 

--- a/src/services/autosave.js
+++ b/src/services/autosave.js
@@ -84,9 +84,10 @@ export class AutosaveService {
   }
 
   /**
-   * Convert AudioBuffer to WAV file data
+   * Convert AudioBuffer to WAV file data, optionally restricted to a
+   * sample-index window (used when a clip only references part of its buffer).
    */
-  audioBufferToWav(buffer) {
+  audioBufferToWav(buffer, windowOffset = 0, windowLength = null) {
     const numberOfChannels = buffer.numberOfChannels
     const sampleRate = buffer.sampleRate
     const format = 1 // PCM
@@ -95,11 +96,17 @@ export class AutosaveService {
     const bytesPerSample = bitDepth / 8
     const blockAlign = numberOfChannels * bytesPerSample
 
-    const data = new Float32Array(buffer.length * numberOfChannels)
+    const startSample = Math.max(0, windowOffset | 0)
+    const endSample = windowLength != null
+      ? Math.min(buffer.length, startSample + windowLength)
+      : buffer.length
+    const sampleCount = Math.max(0, endSample - startSample)
+
+    const data = new Float32Array(sampleCount * numberOfChannels)
     for (let channel = 0; channel < numberOfChannels; channel++) {
       const channelData = buffer.getChannelData(channel)
-      for (let i = 0; i < buffer.length; i++) {
-        data[i * numberOfChannels + channel] = channelData[i]
+      for (let i = 0; i < sampleCount; i++) {
+        data[i * numberOfChannels + channel] = channelData[startSample + i]
       }
     }
 
@@ -216,8 +223,13 @@ export class AutosaveService {
                 continue
               }
 
-              // Convert audio buffer to WAV
-              const wavData = this.audioBufferToWav(clip.buffer)
+              // Convert audio buffer to WAV (respecting any window set by
+              // splits so we don't serialize shared parent audio repeatedly)
+              const wavData = this.audioBufferToWav(
+                clip.buffer,
+                clip.bufferOffset || 0,
+                clip.bufferLength ?? null
+              )
 
               // Validate WAV data size (skip if > 50MB)
               if (wavData.byteLength > 50 * 1024 * 1024) {
@@ -372,16 +384,20 @@ export class AutosaveService {
             // Convert WAV to AudioBuffer
             const audioBuffer = await this.wavToAudioBuffer(arrayBuffer)
 
-            // Add clip to track
+            // Add clip to track. Windows are implicitly reset because the
+            // WAV on disk already contains only the saved window.
             const clip = {
               id: clipData.id,
               name: clipData.name,
               buffer: markRaw(audioBuffer),
+              bufferOffset: 0,
+              bufferLength: audioBuffer.length,
               startTime: clipData.startTime,
               duration: clipData.duration,
               color: clipData.color,
-              waveformData: markRaw(this.audioStore.generateWaveformData(audioBuffer))
+              waveformData: null
             }
+            this.audioStore.getOrGenerateClipWaveform(clip)
 
             track.clips.push(clip)
           } catch (error) {

--- a/src/services/autosave.js
+++ b/src/services/autosave.js
@@ -389,13 +389,9 @@ export class AutosaveService {
           }
         }
 
-        // Update track buffer from clips
-        if (track.clips.length > 0) {
-          this.audioStore.updateTrackBufferFromClips(track.id)
-        }
       }
 
-      // Update duration
+      // Update duration (each track's duration is derived from its clips)
       this.audioStore.updateDuration()
 
       console.log('✅ Project restored from OPFS')

--- a/src/services/autosave.js
+++ b/src/services/autosave.js
@@ -2,6 +2,7 @@
  * Autosave Service using OPFS (Origin Private File System)
  * Automatically saves project state including audio buffers to prevent data loss
  */
+import { markRaw } from 'vue'
 
 const AUTOSAVE_DIR = 'webacity-autosave'
 const PROJECT_FILE = 'project.json'
@@ -375,11 +376,11 @@ export class AutosaveService {
             const clip = {
               id: clipData.id,
               name: clipData.name,
-              buffer: audioBuffer,
+              buffer: markRaw(audioBuffer),
               startTime: clipData.startTime,
               duration: clipData.duration,
               color: clipData.color,
-              waveformData: this.audioStore.generateWaveformData(audioBuffer)
+              waveformData: markRaw(this.audioStore.generateWaveformData(audioBuffer))
             }
 
             track.clips.push(clip)

--- a/src/services/autosave.js
+++ b/src/services/autosave.js
@@ -6,15 +6,25 @@ import { markRaw } from 'vue'
 
 const AUTOSAVE_DIR = 'webacity-autosave'
 const PROJECT_FILE = 'project.json'
-const AUTOSAVE_INTERVAL = 30000 // 30 seconds
+// Debounce: wait this long after the last change before writing.
+const AUTOSAVE_DEBOUNCE = 10000 // 10 seconds
 
 export class AutosaveService {
   constructor(audioStore) {
     this.audioStore = audioStore
-    this.intervalId = null
     this.hasUnsavedChanges = false
     this.opfsRoot = null
     this.autosaveDir = null
+    // Per-clip fingerprint ("buffer identity + window + startTime + duration")
+    // so we can skip clips whose on-disk WAV is still current.
+    this.clipFingerprints = new Map()
+    // A single autosave worker handles WAV encoding so the main thread
+    // never stalls on a large buffer serialization.
+    this.worker = null
+    this.nextWorkerId = 1
+    this.workerPending = new Map()
+    this.debounceTimer = null
+    this.saveInFlight = false
   }
 
   /**
@@ -46,41 +56,118 @@ export class AutosaveService {
    * Start autosaving
    */
   async start() {
-    // Initialize OPFS
     const initialized = await this.initOPFS()
     if (!initialized) {
       console.warn('⚠️ Autosave disabled - OPFS not available')
       return
     }
 
-    // Check for existing autosave on startup
+    this._initWorker()
     await this.checkForAutosave()
 
-    // Save every 30 seconds if there are changes
-    this.intervalId = setInterval(() => {
-      if (this.hasUnsavedChanges) {
-        this.save()
-      }
-    }, AUTOSAVE_INTERVAL)
-
-    console.log('✅ Autosave enabled (saves every 30 seconds using OPFS)')
+    console.log('✅ Autosave enabled (debounced 10s, OPFS-backed)')
   }
 
   /**
    * Stop autosaving
    */
   stop() {
-    if (this.intervalId) {
-      clearInterval(this.intervalId)
-      this.intervalId = null
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+      this.debounceTimer = null
+    }
+    if (this.worker) {
+      this.worker.terminate()
+      this.worker = null
+    }
+    this.workerPending.clear()
+  }
+
+  /**
+   * Mark that changes have been made; saves are debounced so a burst of
+   * edits collapses into a single write 10s after the last one.
+   */
+  markChanged() {
+    this.hasUnsavedChanges = true
+    if (!this.autosaveDir) return
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null
+      if (this.hasUnsavedChanges && !this.saveInFlight) {
+        this.save().catch(err => console.error('Autosave failed:', err))
+      }
+    }, AUTOSAVE_DEBOUNCE)
+  }
+
+  _initWorker() {
+    if (this.worker) return
+    this.worker = new Worker(
+      new URL('../workers/autosaveWorker.js', import.meta.url),
+      { type: 'module' }
+    )
+    this.worker.onmessage = (event) => {
+      const { id, type } = event.data
+      const entry = this.workerPending.get(id)
+      if (!entry) return
+      this.workerPending.delete(id)
+      if (type === 'done') entry.resolve(event.data.wav)
+      else entry.reject(new Error(event.data.error))
+    }
+    this.worker.onerror = (err) => {
+      for (const [, entry] of this.workerPending) entry.reject(err)
+      this.workerPending.clear()
     }
   }
 
   /**
-   * Mark that changes have been made
+   * Encode a clip's windowed audio to a WAV ArrayBuffer via the worker.
+   * The channel data is copied (slice) to avoid detaching the AudioBuffer.
    */
-  markChanged() {
-    this.hasUnsavedChanges = true
+  async encodeClipWav(clip) {
+    this._initWorker()
+    const id = this.nextWorkerId++
+    const numChannels = clip.buffer.numberOfChannels
+    const windowOffset = clip.bufferOffset || 0
+    const windowLength = clip.bufferLength ?? clip.buffer.length
+
+    const channels = []
+    const transfers = []
+    for (let ch = 0; ch < numChannels; ch++) {
+      const full = clip.buffer.getChannelData(ch)
+      const copy = full.slice(windowOffset, windowOffset + windowLength)
+      channels.push(copy)
+      transfers.push(copy.buffer)
+    }
+
+    return new Promise((resolve, reject) => {
+      this.workerPending.set(id, { resolve, reject })
+      this.worker.postMessage({
+        id,
+        channels,
+        sampleRate: clip.buffer.sampleRate,
+        // Clip data is already sliced to the window, so pass offset=0, length=full.
+        windowOffset: 0,
+        windowLength: null
+      }, transfers)
+    })
+  }
+
+  _fingerprint(clip) {
+    // Identity of the underlying buffer, plus the window, start, and duration.
+    // A fresh buffer ref means the audio changed (e.g. an effect was applied).
+    return [
+      clip.buffer,
+      clip.bufferOffset || 0,
+      clip.bufferLength ?? (clip.buffer ? clip.buffer.length : 0),
+      clip.startTime,
+      clip.duration
+    ]
+  }
+
+  _fingerprintEquals(a, b) {
+    if (!a || !b) return false
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+    return true
   }
 
   /**
@@ -174,6 +261,12 @@ export class AutosaveService {
       console.warn('⚠️ OPFS not initialized')
       return false
     }
+    if (this.saveInFlight) {
+      // Another save is already running; the post-save change check will pick
+      // up any new edits, so just drop this call.
+      return false
+    }
+    this.saveInFlight = true
 
     try {
       console.log('💾 Saving project to OPFS...')
@@ -207,33 +300,11 @@ export class AutosaveService {
           if (clip.buffer) {
             try {
               const clipFileName = `${track.id}_${clip.id}.wav`
+              const clipWindowDuration = (clip.bufferLength ?? clip.buffer.length) / clip.buffer.sampleRate
 
-              // Skip very large buffers that might cause issues (> 5 minutes)
-              if (clip.buffer.duration > 300) {
-                console.warn(`⚠️ Skipping autosave for large clip: ${clip.name} (${clip.buffer.duration.toFixed(1)}s)`)
-                trackData.clips.push({
-                  id: clip.id,
-                  fileName: null, // Mark as not saved
-                  name: clip.name,
-                  startTime: clip.startTime,
-                  duration: clip.duration,
-                  color: clip.color,
-                  skipped: true
-                })
-                continue
-              }
-
-              // Convert audio buffer to WAV (respecting any window set by
-              // splits so we don't serialize shared parent audio repeatedly)
-              const wavData = this.audioBufferToWav(
-                clip.buffer,
-                clip.bufferOffset || 0,
-                clip.bufferLength ?? null
-              )
-
-              // Validate WAV data size (skip if > 50MB)
-              if (wavData.byteLength > 50 * 1024 * 1024) {
-                console.warn(`⚠️ Skipping autosave for large WAV file: ${clip.name} (${(wavData.byteLength / 1024 / 1024).toFixed(1)}MB)`)
+              // Skip very large buffers (> 5 minutes) with a prominent log.
+              if (clipWindowDuration > 300) {
+                console.warn(`⚠️ AUTOSAVE SKIPPED — clip "${clip.name}" is ${clipWindowDuration.toFixed(1)}s, above the 5-min autosave cap. Use File > Save to persist this project.`)
                 trackData.clips.push({
                   id: clip.id,
                   fileName: null,
@@ -246,13 +317,46 @@ export class AutosaveService {
                 continue
               }
 
-              // Write to OPFS
+              // Skip unchanged clips: reuse the existing on-disk WAV.
+              const fp = this._fingerprint(clip)
+              const lastFp = this.clipFingerprints.get(clip.id)
+              if (this._fingerprintEquals(lastFp, fp)) {
+                trackData.clips.push({
+                  id: clip.id,
+                  fileName: clipFileName,
+                  name: clip.name,
+                  startTime: clip.startTime,
+                  duration: clip.duration,
+                  color: clip.color
+                })
+                continue
+              }
+
+              // Encode WAV off the main thread.
+              const wavData = await this.encodeClipWav(clip)
+
+              // Validate WAV data size (skip if > 50MB)
+              if (wavData.byteLength > 50 * 1024 * 1024) {
+                console.warn(`⚠️ AUTOSAVE SKIPPED — encoded WAV for "${clip.name}" is ${(wavData.byteLength / 1024 / 1024).toFixed(1)} MB, above the 50 MB autosave cap.`)
+                trackData.clips.push({
+                  id: clip.id,
+                  fileName: null,
+                  name: clip.name,
+                  startTime: clip.startTime,
+                  duration: clip.duration,
+                  color: clip.color,
+                  skipped: true
+                })
+                continue
+              }
+
               const fileHandle = await this.autosaveDir.getFileHandle(clipFileName, { create: true })
               const writable = await fileHandle.createWritable()
               await writable.write(wavData)
               await writable.close()
 
-              // Save clip metadata
+              this.clipFingerprints.set(clip.id, fp)
+
               trackData.clips.push({
                 id: clip.id,
                 fileName: clipFileName,
@@ -293,6 +397,8 @@ export class AutosaveService {
     } catch (error) {
       console.error('❌ Autosave failed:', error)
       return false
+    } finally {
+      this.saveInFlight = false
     }
   }
 

--- a/src/stores/audioStore.js
+++ b/src/stores/audioStore.js
@@ -58,10 +58,17 @@ export const useAudioStore = defineStore('audio', {
 
     trackCount: (state) => state.tracks.length,
 
-    hasAudio: (state) => state.tracks.some(t => t.buffer !== null),
+    hasAudio: (state) => state.tracks.some(t => t.clips && t.clips.length > 0),
 
     longestTrackDuration: (state) => {
-      return Math.max(0, ...state.tracks.map(t => t.duration || 0))
+      let max = 0
+      for (const track of state.tracks) {
+        for (const clip of track.clips || []) {
+          const end = clip.startTime + clip.duration
+          if (end > max) max = end
+        }
+      }
+      return max
     },
 
     hasSelection: (state) => state.selection !== null,
@@ -319,12 +326,22 @@ export const useAudioStore = defineStore('audio', {
     },
 
     /**
-     * Play audio
+     * Play audio by scheduling each clip on its track as a BufferSource.
+     * Avoids ever pre-mixing clips into a single track buffer.
      */
     play() {
       if (!this.engine || !this.hasAudio) return
 
-      this.engine.play(this.currentTime)
+      this.engine.resume()
+      // Small lookahead so the first scheduled source has time to be ready.
+      const contextStartTime = this.engine.audioContext.currentTime + 0.1
+
+      for (const track of this.tracks) {
+        if (track.muted) continue
+        this.engine.playTrackClips(track.id, track.clips, this.currentTime, contextStartTime)
+      }
+
+      this.engine.isPlaying = true
       this.isPlaying = true
     },
 
@@ -434,8 +451,9 @@ export const useAudioStore = defineStore('audio', {
       try {
         console.log(`📤 Exporting project as ${exportFormat.toUpperCase()} (quality: ${exportQuality})...`)
 
-        // Get mixed audio buffer from engine
-        const mixedBuffer = this.engine.getMixedBuffer()
+        // Render all clips into a single buffer via an OfflineAudioContext.
+        // During editing nothing mixes - this happens only on export.
+        const mixedBuffer = await this.computeMixedBuffer()
         if (!mixedBuffer) {
           console.error('❌ Failed to get mixed buffer')
           return null
@@ -459,8 +477,7 @@ export const useAudioStore = defineStore('audio', {
 
             if (!loaded) {
               console.warn(`⚠️ FFmpeg failed to load. Falling back to WAV export.`)
-              // Fall back to WAV export
-              blob = this.engine.exportMix()
+              blob = this.engine.bufferToWav(mixedBuffer)
               filename = `${this.projectName || 'project'}.wav`
             }
           }
@@ -485,15 +502,14 @@ export const useAudioStore = defineStore('audio', {
               console.log(`✅ FFmpeg export successful (source: ${ffmpegService.loadSource})`)
             } catch (ffmpegError) {
               console.warn('⚠️ FFmpeg export failed, falling back to WAV:', ffmpegError.message)
-              // Fall back to WAV
-              blob = this.engine.exportMix()
+              blob = this.engine.bufferToWav(mixedBuffer)
               filename = `${this.projectName || 'project'}.wav`
             }
           }
         } else {
           // Direct WAV export (no FFmpeg needed)
           console.log('🎵 Exporting to WAV...')
-          blob = this.engine.exportMix()
+          blob = this.engine.bufferToWav(mixedBuffer)
           filename = `${this.projectName || 'project'}.wav`
         }
 
@@ -525,6 +541,25 @@ export const useAudioStore = defineStore('audio', {
     },
 
     /**
+     * Render all clips from all tracks into a single AudioBuffer via an
+     * OfflineAudioContext. Used for export; never stored in memory during
+     * editing.
+     */
+    async computeMixedBuffer() {
+      if (!this.engine || !this.hasAudio) return null
+
+      const trackSpecs = this.tracks.map(t => ({
+        id: t.id,
+        clips: t.clips,
+        volume: t.volume,
+        pan: t.pan,
+        muted: t.muted
+      }))
+
+      return await this.engine.renderTracksOffline(trackSpecs, this.masterVolume)
+    },
+
+    /**
      * Set export format
      */
     setExportFormat(format) {
@@ -544,9 +579,18 @@ export const useAudioStore = defineStore('audio', {
     },
 
     /**
-     * Update total duration
+     * Update each track's duration from its clips and the project duration
+     * from the longest track.
      */
     updateDuration() {
+      for (const track of this.tracks) {
+        let end = 0
+        for (const clip of track.clips) {
+          const clipEnd = clip.startTime + clip.duration
+          if (clipEnd > end) end = clipEnd
+        }
+        track.duration = end
+      }
       this.duration = this.longestTrackDuration
     },
 
@@ -586,9 +630,6 @@ export const useAudioStore = defineStore('audio', {
 
         // Force reactivity
         track.clips = [...track.clips]
-
-        // Rebuild track buffer from clips
-        this.updateTrackBufferFromClips(track.id)
       })
 
       // Update total duration
@@ -713,7 +754,9 @@ export const useAudioStore = defineStore('audio', {
       if (!this.selection) return false
 
       const track = this.tracks.find(t => t.id === this.selection.trackId)
-      if (!track || !track.buffer) return false
+      if (!track) return false
+      if (!track.buffer) this.updateTrackBufferFromClips(this.selection.trackId)
+      if (!track.buffer) return false
 
       const { startTime, endTime } = this.selection
       const startSample = Math.floor(startTime * this.sampleRate)
@@ -754,7 +797,9 @@ export const useAudioStore = defineStore('audio', {
      */
     deleteSelection(trackId, selection) {
       const track = this.tracks.find(t => t.id === trackId)
-      if (!track || !track.buffer || !selection) return false
+      if (!track || !selection) return false
+      if (!track.buffer) this.updateTrackBufferFromClips(trackId)
+      if (!track.buffer) return false
 
       const { startTime, endTime } = selection
       const startSample = Math.floor(startTime * this.sampleRate)
@@ -791,76 +836,15 @@ export const useAudioStore = defineStore('audio', {
     },
 
     /**
-     * Paste clipboard at current position
+     * Paste clipboard at current position as a new clip.
+     * Previously this spliced the clipboard into a single track buffer; with
+     * the clip-based engine we simply add a clip at the target time.
      */
     pasteAtPosition(trackId, clipboardBuffer, position) {
       const track = this.tracks.find(t => t.id === trackId)
       if (!track || !clipboardBuffer) return false
 
-      const positionSample = Math.floor(position * this.sampleRate)
-      const clipLength = clipboardBuffer.length
-
-      // If track is empty, create a buffer with the clipboard at the specified position
-      if (!track.buffer) {
-        const newLength = positionSample + clipLength
-
-        // Create new buffer filled with silence
-        const newBuffer = this.engine.audioContext.createBuffer(
-          clipboardBuffer.numberOfChannels,
-          newLength,
-          this.sampleRate
-        )
-
-        // Copy clipboard data at the specified position
-        for (let ch = 0; ch < clipboardBuffer.numberOfChannels; ch++) {
-          const destData = newBuffer.getChannelData(ch)
-          const clipData = clipboardBuffer.getChannelData(ch)
-
-          // Place clipboard at position (buffer is already zeroed/silent)
-          for (let i = 0; i < clipLength; i++) {
-            destData[positionSample + i] = clipData[i]
-          }
-        }
-
-        // Update track
-        track.buffer = markRaw(newBuffer)
-        track.duration = newBuffer.duration
-        this.engine.setTrackBuffer(trackId, newBuffer)
-        track.waveformData = markRaw(this.generateWaveformData(newBuffer))
-        this.updateDuration()
-        console.log('Pasted into empty track at position', position)
-        return true
-      }
-
-      // Track has audio - insert clipboard at position (splice)
-      const newLength = track.buffer.length + clipLength
-
-      // Create new buffer with pasted audio
-      const newBuffer = this.engine.audioContext.createBuffer(
-        track.buffer.numberOfChannels,
-        newLength,
-        this.sampleRate
-      )
-
-      for (let ch = 0; ch < track.buffer.numberOfChannels; ch++) {
-        const originalData = track.buffer.getChannelData(ch)
-        const clipData = clipboardBuffer.getChannelData(ch % clipboardBuffer.numberOfChannels)
-        const newData = newBuffer.getChannelData(ch)
-
-        // Copy before paste position
-        newData.set(originalData.slice(0, positionSample), 0)
-        // Copy clipboard
-        newData.set(clipData, positionSample)
-        // Copy after paste position
-        newData.set(originalData.slice(positionSample), positionSample + clipLength)
-      }
-
-      track.buffer = markRaw(newBuffer)
-      track.duration = newBuffer.duration
-      this.engine.setTrackBuffer(trackId, newBuffer)
-      track.waveformData = markRaw(this.generateWaveformData(newBuffer))
-      this.updateDuration()
-
+      this.addClipToTrack(trackId, clipboardBuffer, position, 'Pasted')
       return true
     },
 
@@ -978,9 +962,7 @@ export const useAudioStore = defineStore('audio', {
         track.clips.splice(clipIndex, 1, updatedClip)
 
         console.log('Updated clips array')
-
-        // Rebuild track buffer from all clips
-        this.updateTrackBufferFromClips(trackId)
+        this.updateDuration()
 
         console.log(`Applied ${effectName} to clip "${clip.name}" - effect complete`)
         return true
@@ -995,7 +977,9 @@ export const useAudioStore = defineStore('audio', {
      */
     async applyEffectToTrack(trackId, effectName, params, selection = null) {
       const track = this.tracks.find(t => t.id === trackId)
-      if (!track || !track.buffer) return
+      if (!track) return
+      if (!track.buffer) this.updateTrackBufferFromClips(trackId)
+      if (!track.buffer) return
 
       try {
         let channelData = track.buffer.getChannelData(0)
@@ -1217,7 +1201,11 @@ export const useAudioStore = defineStore('audio', {
      */
     analyzeTrack(trackId) {
       const track = this.tracks.find(t => t.id === trackId)
-      if (!track || !track.buffer) return null
+      if (!track) return null
+      // track.buffer isn't maintained during editing anymore - build it now
+      // on demand from the track's clips.
+      if (!track.buffer) this.updateTrackBufferFromClips(trackId)
+      if (!track.buffer) return null
 
       const tempo = this.analyzer.estimateTempo(track.buffer)
       const peaks = this.analyzer.findPeaks(track.buffer)
@@ -1240,7 +1228,9 @@ export const useAudioStore = defineStore('audio', {
      */
     generateSpectrogram(trackId) {
       const track = this.tracks.find(t => t.id === trackId)
-      if (!track || !track.buffer) return null
+      if (!track) return null
+      if (!track.buffer) this.updateTrackBufferFromClips(trackId)
+      if (!track.buffer) return null
 
       return this.analyzer.generateSpectrogram(track.buffer)
     },
@@ -1252,7 +1242,9 @@ export const useAudioStore = defineStore('audio', {
       if (!this.selection) return null
 
       const track = this.tracks.find(t => t.id === this.selection.trackId)
-      if (!track || !track.buffer) return null
+      if (!track) return null
+      if (!track.buffer) this.updateTrackBufferFromClips(this.selection.trackId)
+      if (!track.buffer) return null
 
       const { startTime, endTime } = this.selection
       const duration = endTime - startTime
@@ -1347,7 +1339,6 @@ export const useAudioStore = defineStore('audio', {
       }
 
       track.clips.push(clip)
-      this.updateTrackBufferFromClips(trackId)
       this.updateDuration()
 
       return clip
@@ -1398,11 +1389,6 @@ export const useAudioStore = defineStore('audio', {
       // Remove clip
       track.clips.splice(index, 1)
 
-      // Force Vue reactivity by reassigning array
-      track.clips = [...track.clips]
-
-      // Rebuild track buffer and update duration
-      this.updateTrackBufferFromClips(trackId)
       this.updateDuration()
 
       console.log(`Removed clip ${clipId} from track ${trackId}`)
@@ -1558,8 +1544,7 @@ export const useAudioStore = defineStore('audio', {
       // Insert the second clip right after the first one
       track.clips.splice(clipIndex + 1, 0, secondClip)
 
-      // Rebuild the track buffer from all clips
-      this.updateTrackBufferFromClips(trackId)
+      this.updateDuration()
 
       console.log(`Split clip "${clip.name}" at ${splitTime.toFixed(2)}s`)
       return true

--- a/src/stores/audioStore.js
+++ b/src/stores/audioStore.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { markRaw } from 'vue'
 import AudioEngine from '../audio/AudioEngine'
 import WasmBridge from '../audio/WasmBridge'
 import AudioRecorder from '../audio/AudioRecorder'
@@ -644,7 +645,7 @@ export const useAudioStore = defineStore('audio', {
 
       // Copy clip data to clipboard
       this.clipboard = {
-        buffer: clip.buffer,
+        buffer: markRaw(clip.buffer),
         duration: clip.duration,
         startTime: 0 // Will be pasted at cursor position
       }
@@ -733,7 +734,7 @@ export const useAudioStore = defineStore('audio', {
       }
 
       this.clipboard = {
-        buffer: clipBuffer,
+        buffer: markRaw(clipBuffer),
         duration: endTime - startTime
       }
 
@@ -779,10 +780,10 @@ export const useAudioStore = defineStore('audio', {
         newData.set(originalData.slice(endSample), startSample)
       }
 
-      track.buffer = newBuffer
+      track.buffer = markRaw(newBuffer)
       track.duration = newBuffer.duration
       this.engine.setTrackBuffer(trackId, newBuffer)
-      track.waveformData = this.generateWaveformData(newBuffer)
+      track.waveformData = markRaw(this.generateWaveformData(newBuffer))
       this.updateDuration()
       this.clearSelection()
 
@@ -822,10 +823,10 @@ export const useAudioStore = defineStore('audio', {
         }
 
         // Update track
-        track.buffer = newBuffer
+        track.buffer = markRaw(newBuffer)
         track.duration = newBuffer.duration
         this.engine.setTrackBuffer(trackId, newBuffer)
-        track.waveformData = this.generateWaveformData(newBuffer)
+        track.waveformData = markRaw(this.generateWaveformData(newBuffer))
         this.updateDuration()
         console.log('Pasted into empty track at position', position)
         return true
@@ -854,10 +855,10 @@ export const useAudioStore = defineStore('audio', {
         newData.set(originalData.slice(positionSample), positionSample + clipLength)
       }
 
-      track.buffer = newBuffer
+      track.buffer = markRaw(newBuffer)
       track.duration = newBuffer.duration
       this.engine.setTrackBuffer(trackId, newBuffer)
-      track.waveformData = this.generateWaveformData(newBuffer)
+      track.waveformData = markRaw(this.generateWaveformData(newBuffer))
       this.updateDuration()
 
       return true
@@ -967,19 +968,14 @@ export const useAudioStore = defineStore('audio', {
         // Create a new clip object with updated buffer and waveform (to trigger Vue reactivity)
         const updatedClip = {
           ...clip,
-          buffer: newBuffer,
-          waveformData: this.generateWaveformData(newBuffer),
-          // Add a timestamp to force reactivity
-          _lastModified: Date.now()
+          buffer: markRaw(newBuffer),
+          waveformData: markRaw(this.generateWaveformData(newBuffer))
         }
 
         console.log('Created updated clip with new waveform data')
 
         // Replace the clip in the array (this triggers Vue reactivity)
         track.clips.splice(clipIndex, 1, updatedClip)
-
-        // Force reactivity by reassigning the clips array
-        track.clips = [...track.clips]
 
         console.log('Updated clips array')
 
@@ -1085,9 +1081,9 @@ export const useAudioStore = defineStore('audio', {
         }
 
         // Update track
-        track.buffer = newBuffer
+        track.buffer = markRaw(newBuffer)
         this.engine.setTrackBuffer(trackId, newBuffer)
-        track.waveformData = this.generateWaveformData(newBuffer)
+        track.waveformData = markRaw(this.generateWaveformData(newBuffer))
 
         console.log(`Applied ${effectName} to track ${trackId}${selection ? ' (selection)' : ''}`)
       } catch (error) {
@@ -1290,9 +1286,9 @@ export const useAudioStore = defineStore('audio', {
       const snippet = {
         id: snippetId,
         name: snippetName,
-        buffer: snippetBuffer,
+        buffer: markRaw(snippetBuffer),
         duration,
-        waveformData: this.generateWaveformData(snippetBuffer)
+        waveformData: markRaw(this.generateWaveformData(snippetBuffer))
       }
 
       this.snippets.push(snippet)
@@ -1343,10 +1339,10 @@ export const useAudioStore = defineStore('audio', {
       const clip = {
         id: clipId,
         name: name || `Clip ${track.clips.length + 1}`,
-        buffer,
+        buffer: markRaw(buffer),
         startTime,
         duration: buffer.duration,
-        waveformData: this.generateWaveformData(buffer),
+        waveformData: markRaw(this.generateWaveformData(buffer)),
         color: track.color
       }
 
@@ -1468,9 +1464,9 @@ export const useAudioStore = defineStore('audio', {
       }
 
       // Update track
-      track.buffer = mixedBuffer
+      track.buffer = markRaw(mixedBuffer)
       track.duration = maxEndTime
-      track.waveformData = this.generateWaveformData(mixedBuffer)
+      track.waveformData = markRaw(this.generateWaveformData(mixedBuffer))
       this.engine.setTrackBuffer(trackId, mixedBuffer)
     },
 
@@ -1544,18 +1540,18 @@ export const useAudioStore = defineStore('audio', {
       }
 
       // Update the original clip to be the first part
-      clip.buffer = firstBuffer
+      clip.buffer = markRaw(firstBuffer)
       clip.duration = firstBuffer.duration
-      clip.waveformData = this.generateWaveformData(firstBuffer)
+      clip.waveformData = markRaw(this.generateWaveformData(firstBuffer))
 
       // Create new clip for the second part
       const secondClip = {
         id: `clip_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         name: `${clip.name} (2)`,
-        buffer: secondBuffer,
+        buffer: markRaw(secondBuffer),
         startTime: splitTime,
         duration: secondBuffer.duration,
-        waveformData: this.generateWaveformData(secondBuffer),
+        waveformData: markRaw(this.generateWaveformData(secondBuffer)),
         color: clip.color
       }
 

--- a/src/stores/audioStore.js
+++ b/src/stores/audioStore.js
@@ -6,6 +6,7 @@ import AudioRecorder from '../audio/AudioRecorder'
 import AudioGenerators from '../audio/AudioGenerators'
 import AdvancedEffects from '../audio/AdvancedEffects'
 import AudioAnalyzer from '../audio/AudioAnalyzer'
+import EffectsWorkerClient from '../audio/EffectsWorkerClient'
 import ffmpegService from '../services/ffmpegService'
 import { useHistoryStore } from './historyStore'
 import { DeleteClipCommand, MoveClipCommand, CutClipCommand, PasteClipCommand } from '../utils/commands'
@@ -39,7 +40,10 @@ export const useAudioStore = defineStore('audio', {
     exportFormat: 'mp3', // Export format: 'mp3', 'aac', 'opus', 'flac', 'wav'
     exportQuality: 192, // Export quality/bitrate
     ffmpegLoading: false,
-    ffmpegLoadProgress: 0
+    ffmpegLoadProgress: 0,
+    // { clipId, effectName, percent } while an effect is running, otherwise null.
+    effectProgress: null,
+    effectsWorker: null
   }),
 
   getters: {
@@ -103,6 +107,7 @@ export const useAudioStore = defineStore('audio', {
         this.generators = new AudioGenerators(this.engine.audioContext, this.sampleRate)
         this.advancedEffects = new AdvancedEffects(this.sampleRate)
         this.analyzer = new AudioAnalyzer(this.engine.audioContext, this.sampleRate)
+        this.effectsWorker = markRaw(new EffectsWorkerClient())
 
         this.isInitialized = true
 
@@ -908,91 +913,51 @@ export const useAudioStore = defineStore('audio', {
       const track = this.tracks.find(t => t.id === trackId)
       if (!track) return false
 
+      // Effects only operate on the clip's current window. Building a new
+      // buffer with exactly that window also drops any shared-parent audio
+      // outside it, preventing the effect output from leaking into sibling
+      // clips that reference the same underlying buffer.
+      const windowOffset = clip.bufferOffset || 0
+      const windowLength = clip.bufferLength ?? clip.buffer.length
+      const numChannels = clip.buffer.numberOfChannels
+      const sampleRate = clip.buffer.sampleRate
+
+      // Copy each channel's window into its own transferable Float32Array.
+      const channelBuffers = []
+      for (let ch = 0; ch < numChannels; ch++) {
+        const full = clip.buffer.getChannelData(ch)
+        channelBuffers.push(full.slice(windowOffset, windowOffset + windowLength))
+      }
+
+      this.effectProgress = { clipId: this.selectedClipId, effectName, percent: 0 }
       try {
-        // Effects only operate on the clip's current window. Building a new
-        // buffer with exactly that window also drops any shared-parent audio
-        // outside it, preventing the effect output from leaking into sibling
-        // clips that reference the same underlying buffer.
-        const windowOffset = clip.bufferOffset || 0
-        const windowLength = clip.bufferLength ?? clip.buffer.length
-        const newBuffer = this.engine.audioContext.createBuffer(
-          clip.buffer.numberOfChannels,
-          windowLength,
-          clip.buffer.sampleRate
+        const processedBuffers = await this.effectsWorker.process(
+          effectName,
+          params,
+          channelBuffers,
+          sampleRate,
+          (percent) => {
+            if (this.effectProgress) this.effectProgress.percent = percent
+          }
         )
 
-        // Process ALL channels (not just stereo)
-        for (let ch = 0; ch < clip.buffer.numberOfChannels; ch++) {
-          const fullChannel = clip.buffer.getChannelData(ch)
-          const channelData = fullChannel.subarray(windowOffset, windowOffset + windowLength)
-          let processedData
-
-          // Apply effect using WASM bridge or advancedEffects
-          switch (effectName) {
-            case 'amplify':
-              processedData = this.wasmBridge.amplify(channelData, params.factor)
-              break
-            case 'normalize':
-              processedData = this.wasmBridge.normalize(channelData, params.targetPeak)
-              break
-            case 'fadeIn':
-              processedData = this.wasmBridge.fadeIn(channelData, params.samples)
-              break
-            case 'fadeOut':
-              processedData = this.wasmBridge.fadeOut(channelData, params.samples)
-              break
-            case 'reverse':
-              processedData = this.wasmBridge.reverse(channelData)
-              break
-            case 'lowPass':
-              processedData = this.wasmBridge.lowPassFilter(channelData, params.cutoff)
-              break
-            case 'highPass':
-              processedData = this.wasmBridge.highPassFilter(channelData, params.cutoff)
-              break
-            case 'compress':
-              processedData = this.wasmBridge.compress(
-                channelData,
-                params.threshold,
-                params.ratio,
-                params.attack,
-                params.release
-              )
-              break
-            case 'reverb':
-              processedData = this.advancedEffects.reverb(
-                channelData,
-                params.roomSize,
-                params.damping,
-                params.wetLevel,
-                params.dryLevel
-              )
-              break
-            case 'equalizer':
-              processedData = this.advancedEffects.equalizer(channelData, params.bands)
-              break
-            case 'pitch':
-              processedData = this.advancedEffects.changePitch(channelData, params.semitones)
-              break
-            default:
-              console.warn('Unknown effect:', effectName)
-              return false
-          }
-
-          // Copy processed data to new buffer channel
-          newBuffer.getChannelData(ch).set(processedData)
+        // Effects like pitch change the length, so size the buffer to match.
+        const newLength = processedBuffers[0]?.length ?? windowLength
+        const newBuffer = this.engine.audioContext.createBuffer(
+          numChannels,
+          newLength,
+          sampleRate
+        )
+        for (let ch = 0; ch < numChannels; ch++) {
+          newBuffer.copyToChannel(processedBuffers[ch], ch, 0)
         }
 
-        // Find the clip index in the track
         const clipIndex = track.clips.findIndex(c => c.id === this.selectedClipId)
         if (clipIndex === -1) {
           console.error('Clip index not found!')
           return false
         }
 
-        console.log('Found clip at index:', clipIndex)
-
-        // Create a new clip object with updated buffer and waveform (to trigger Vue reactivity)
         const updatedClip = {
           ...clip,
           buffer: markRaw(newBuffer),
@@ -1004,12 +969,7 @@ export const useAudioStore = defineStore('audio', {
         }
         this.getOrGenerateClipWaveform(updatedClip)
 
-        console.log('Created updated clip with new waveform data')
-
-        // Replace the clip in the array (this triggers Vue reactivity)
         track.clips.splice(clipIndex, 1, updatedClip)
-
-        console.log('Updated clips array')
         this.updateDuration()
 
         console.log(`Applied ${effectName} to clip "${clip.name}" - effect complete`)
@@ -1017,6 +977,8 @@ export const useAudioStore = defineStore('audio', {
       } catch (error) {
         console.error('Failed to apply effect to clip:', error)
         throw error
+      } finally {
+        this.effectProgress = null
       }
     },
 

--- a/src/stores/audioStore.js
+++ b/src/stores/audioStore.js
@@ -300,20 +300,31 @@ export const useAudioStore = defineStore('audio', {
     },
 
     /**
-     * Generate waveform visualization data
+     * Generate waveform visualization data. If the clip defines a window via
+     * bufferOffset/bufferLength (sample indices), only that region of the
+     * underlying buffer is sampled - so a split clip can share its parent's
+     * buffer without copying audio.
      */
-    generateWaveformData(buffer, samples = 1000) {
+    generateWaveformData(buffer, samples = 2000, bufferOffset = 0, bufferLength = null) {
       const channelData = buffer.getChannelData(0)
-      const blockSize = Math.floor(channelData.length / samples)
+      const startSample = Math.max(0, bufferOffset | 0)
+      const endSample = bufferLength != null
+        ? Math.min(channelData.length, startSample + bufferLength)
+        : channelData.length
+      const region = endSample - startSample
+      if (region <= 0) return []
+
+      const blockSize = Math.max(1, Math.floor(region / samples))
       const waveformData = []
 
       for (let i = 0; i < samples; i++) {
-        const start = i * blockSize
-        const end = start + blockSize
+        const start = startSample + i * blockSize
+        const end = Math.min(endSample, start + blockSize)
+        if (start >= endSample) break
         let min = 1
         let max = -1
 
-        for (let j = start; j < end && j < channelData.length; j++) {
+        for (let j = start; j < end; j++) {
           const value = channelData[j]
           if (value < min) min = value
           if (value > max) max = value
@@ -323,6 +334,30 @@ export const useAudioStore = defineStore('audio', {
       }
 
       return waveformData
+    },
+
+    /**
+     * Return a cached waveform for this clip, respecting bufferOffset/
+     * bufferLength when set. The cache key is the buffer reference + window
+     * so splits that share a parent buffer don't invalidate each other.
+     */
+    getOrGenerateClipWaveform(clip) {
+      if (clip.waveformData && clip._waveformBufferRef === clip.buffer &&
+          clip._waveformOffset === (clip.bufferOffset || 0) &&
+          clip._waveformLength === (clip.bufferLength ?? null)) {
+        return clip.waveformData
+      }
+      const data = markRaw(this.generateWaveformData(
+        clip.buffer,
+        2000,
+        clip.bufferOffset || 0,
+        clip.bufferLength ?? null
+      ))
+      clip.waveformData = data
+      clip._waveformBufferRef = clip.buffer
+      clip._waveformOffset = clip.bufferOffset || 0
+      clip._waveformLength = clip.bufferLength ?? null
+      return data
     },
 
     /**
@@ -687,6 +722,8 @@ export const useAudioStore = defineStore('audio', {
       // Copy clip data to clipboard
       this.clipboard = {
         buffer: markRaw(clip.buffer),
+        bufferOffset: clip.bufferOffset || 0,
+        bufferLength: clip.bufferLength ?? clip.buffer.length,
         duration: clip.duration,
         startTime: 0 // Will be pasted at cursor position
       }
@@ -872,16 +909,22 @@ export const useAudioStore = defineStore('audio', {
       if (!track) return false
 
       try {
-        // Create new buffer with same properties
+        // Effects only operate on the clip's current window. Building a new
+        // buffer with exactly that window also drops any shared-parent audio
+        // outside it, preventing the effect output from leaking into sibling
+        // clips that reference the same underlying buffer.
+        const windowOffset = clip.bufferOffset || 0
+        const windowLength = clip.bufferLength ?? clip.buffer.length
         const newBuffer = this.engine.audioContext.createBuffer(
           clip.buffer.numberOfChannels,
-          clip.buffer.length,
+          windowLength,
           clip.buffer.sampleRate
         )
 
         // Process ALL channels (not just stereo)
         for (let ch = 0; ch < clip.buffer.numberOfChannels; ch++) {
-          const channelData = clip.buffer.getChannelData(ch)
+          const fullChannel = clip.buffer.getChannelData(ch)
+          const channelData = fullChannel.subarray(windowOffset, windowOffset + windowLength)
           let processedData
 
           // Apply effect using WASM bridge or advancedEffects
@@ -953,8 +996,13 @@ export const useAudioStore = defineStore('audio', {
         const updatedClip = {
           ...clip,
           buffer: markRaw(newBuffer),
-          waveformData: markRaw(this.generateWaveformData(newBuffer))
+          bufferOffset: 0,
+          bufferLength: newBuffer.length,
+          duration: newBuffer.duration,
+          waveformData: null,
+          _waveformBufferRef: null
         }
+        this.getOrGenerateClipWaveform(updatedClip)
 
         console.log('Created updated clip with new waveform data')
 
@@ -1321,22 +1369,31 @@ export const useAudioStore = defineStore('audio', {
     },
 
     /**
-     * Add clip to track
+     * Add clip to track. Callers can pass an optional window into the buffer
+     * via opts.bufferOffset / opts.bufferLength (samples) - used by paste to
+     * preserve a split clip's window without duplicating the buffer.
      */
-    addClipToTrack(trackId, buffer, startTime = 0, name = null) {
+    addClipToTrack(trackId, buffer, startTime = 0, name = null, opts = {}) {
       const track = this.tracks.find(t => t.id === trackId)
       if (!track) return null
+
+      const bufferOffset = opts.bufferOffset || 0
+      const bufferLength = opts.bufferLength ?? buffer.length
+      const sampleRate = buffer.sampleRate
 
       const clipId = `clip_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
       const clip = {
         id: clipId,
         name: name || `Clip ${track.clips.length + 1}`,
         buffer: markRaw(buffer),
+        bufferOffset,
+        bufferLength,
         startTime,
-        duration: buffer.duration,
-        waveformData: markRaw(this.generateWaveformData(buffer)),
+        duration: bufferLength / sampleRate,
+        waveformData: null,
         color: track.color
       }
+      this.getOrGenerateClipWaveform(clip)
 
       track.clips.push(clip)
       this.updateDuration()
@@ -1487,59 +1544,37 @@ export const useAudioStore = defineStore('audio', {
         return false
       }
 
-      // Calculate the split point within the clip's buffer
-      const relativeTime = splitTime - clip.startTime
+      // Work in the underlying buffer's sample space. Respect any existing
+      // window so splitting a split-of-a-split stays zero-copy.
       const sampleRate = clip.buffer.sampleRate
+      const parentOffset = clip.bufferOffset || 0
+      const parentLength = clip.bufferLength ?? (clip.buffer.length - parentOffset)
+      const relativeTime = splitTime - clip.startTime
       const splitSample = Math.floor(relativeTime * sampleRate)
+      const firstLength = splitSample
+      const secondLength = parentLength - splitSample
 
-      // Create first part (clip start to split point)
-      const firstPartLength = splitSample
-      const firstBuffer = this.engine.audioContext.createBuffer(
-        clip.buffer.numberOfChannels,
-        firstPartLength,
-        sampleRate
-      )
+      // First part: same buffer, same offset, shorter length.
+      clip.bufferOffset = parentOffset
+      clip.bufferLength = firstLength
+      clip.duration = firstLength / sampleRate
+      // Invalidate cached waveform since the window shrank.
+      clip.waveformData = null
+      this.getOrGenerateClipWaveform(clip)
 
-      // Create second part (split point to clip end)
-      const secondPartLength = clip.buffer.length - splitSample
-      const secondBuffer = this.engine.audioContext.createBuffer(
-        clip.buffer.numberOfChannels,
-        secondPartLength,
-        sampleRate
-      )
-
-      // Copy audio data
-      for (let channel = 0; channel < clip.buffer.numberOfChannels; channel++) {
-        const sourceData = clip.buffer.getChannelData(channel)
-        const firstData = firstBuffer.getChannelData(channel)
-        const secondData = secondBuffer.getChannelData(channel)
-
-        // Copy first part
-        for (let i = 0; i < firstPartLength; i++) {
-          firstData[i] = sourceData[i]
-        }
-
-        // Copy second part
-        for (let i = 0; i < secondPartLength; i++) {
-          secondData[i] = sourceData[splitSample + i]
-        }
-      }
-
-      // Update the original clip to be the first part
-      clip.buffer = markRaw(firstBuffer)
-      clip.duration = firstBuffer.duration
-      clip.waveformData = markRaw(this.generateWaveformData(firstBuffer))
-
-      // Create new clip for the second part
+      // Second part: same buffer, shifted offset, remaining length.
       const secondClip = {
         id: `clip_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         name: `${clip.name} (2)`,
-        buffer: markRaw(secondBuffer),
+        buffer: markRaw(clip.buffer),
+        bufferOffset: parentOffset + splitSample,
+        bufferLength: secondLength,
         startTime: splitTime,
-        duration: secondBuffer.duration,
-        waveformData: markRaw(this.generateWaveformData(secondBuffer)),
+        duration: secondLength / sampleRate,
+        waveformData: null,
         color: clip.color
       }
+      this.getOrGenerateClipWaveform(secondClip)
 
       // Insert the second clip right after the first one
       track.clips.splice(clipIndex + 1, 0, secondClip)

--- a/src/stores/historyStore.js
+++ b/src/stores/historyStore.js
@@ -4,7 +4,9 @@ export const useHistoryStore = defineStore('history', {
   state: () => ({
     undoStack: [],
     redoStack: [],
-    maxHistorySize: 50
+    // Lower than a typical editor because each audio history entry can hold
+    // hundreds of MB of AudioBuffer references.
+    maxHistorySize: 20
   }),
 
   getters: {

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -43,12 +43,13 @@ export class DeleteClipCommand {
   }
 
   execute() {
-    // Save clip data before deleting
+    // Save clip data before deleting. AudioBuffer is immutable once created,
+    // so holding a reference is safe - no clone needed.
     const track = this.audioStore.tracks.find(t => t.id === this.trackId)
     if (track) {
       const clip = track.clips.find(c => c.id === this.clipId)
       if (clip) {
-        this.savedClip = { ...clip, buffer: this.cloneBuffer(clip.buffer) }
+        this.savedClip = { ...clip }
       }
     }
     this.audioStore.removeClip(this.trackId, this.clipId)
@@ -63,20 +64,6 @@ export class DeleteClipCommand {
         this.savedClip.name
       )
     }
-  }
-
-  cloneBuffer(buffer) {
-    const clone = this.audioStore.engine.audioContext.createBuffer(
-      buffer.numberOfChannels,
-      buffer.length,
-      buffer.sampleRate
-    )
-
-    for (let i = 0; i < buffer.numberOfChannels; i++) {
-      clone.getChannelData(i).set(buffer.getChannelData(i))
-    }
-
-    return clone
   }
 }
 
@@ -276,12 +263,12 @@ export class SplitClipCommand {
   }
 
   execute() {
-    // Save original clip before splitting
+    // Save original clip before splitting (AudioBuffer is immutable, reference is safe)
     const track = this.audioStore.tracks.find(t => t.id === this.trackId)
     if (track) {
       const clip = track.clips.find(c => c.id === this.clipId)
       if (clip) {
-        this.originalClip = { ...clip, buffer: this.cloneBuffer(clip.buffer) }
+        this.originalClip = { ...clip }
       }
     }
 
@@ -317,20 +304,6 @@ export class SplitClipCommand {
       this.originalClip.name
     )
   }
-
-  cloneBuffer(buffer) {
-    const clone = this.audioStore.engine.audioContext.createBuffer(
-      buffer.numberOfChannels,
-      buffer.length,
-      buffer.sampleRate
-    )
-
-    for (let i = 0; i < buffer.numberOfChannels; i++) {
-      clone.getChannelData(i).set(buffer.getChannelData(i))
-    }
-
-    return clone
-  }
 }
 
 /**
@@ -351,13 +324,11 @@ export class ApplyEffectToClipCommand {
     const clipData = this.audioStore.selectedClip
     if (clipData) {
       this.trackId = clipData.trackId
-      // Save previous state
+      // Save previous state. AudioBuffer is immutable; once applyEffectToClip
+      // replaces clip.buffer with a new reference, this command's reference
+      // keeps the old buffer alive for undo without any cloning.
       const clip = clipData.clip
-      this.previousClipState = {
-        ...clip,
-        buffer: markRaw(this.cloneBuffer(clip.buffer)),
-        waveformData: markRaw([...clip.waveformData])
-      }
+      this.previousClipState = { ...clip }
     }
 
     // Apply effect
@@ -382,20 +353,6 @@ export class ApplyEffectToClipCommand {
 
     // Rebuild track buffer
     this.audioStore.updateTrackBufferFromClips(this.trackId)
-  }
-
-  cloneBuffer(buffer) {
-    const clone = this.audioStore.engine.audioContext.createBuffer(
-      buffer.numberOfChannels,
-      buffer.length,
-      buffer.sampleRate
-    )
-
-    for (let i = 0; i < buffer.numberOfChannels; i++) {
-      clone.getChannelData(i).set(buffer.getChannelData(i))
-    }
-
-    return clone
   }
 }
 
@@ -433,16 +390,14 @@ export class DeleteTrackCommand {
   }
 
   execute() {
-    // Save track data before deleting
+    // Save track data before deleting. Buffers are immutable - holding
+    // references is enough for undo.
     const track = this.audioStore.tracks.find(t => t.id === this.trackId)
     if (track) {
       this.trackIndex = this.audioStore.tracks.indexOf(track)
       this.savedTrack = {
         ...track,
-        clips: track.clips.map(clip => ({
-          ...clip,
-          buffer: this.cloneBuffer(clip.buffer)
-        }))
+        clips: track.clips.map(clip => ({ ...clip }))
       }
     }
 
@@ -455,20 +410,6 @@ export class DeleteTrackCommand {
       this.audioStore.tracks.splice(this.trackIndex, 0, this.savedTrack)
       this.audioStore.updateDuration()
     }
-  }
-
-  cloneBuffer(buffer) {
-    const clone = this.audioStore.engine.audioContext.createBuffer(
-      buffer.numberOfChannels,
-      buffer.length,
-      buffer.sampleRate
-    )
-
-    for (let i = 0; i < buffer.numberOfChannels; i++) {
-      clone.getChannelData(i).set(buffer.getChannelData(i))
-    }
-
-    return clone
   }
 }
 
@@ -491,8 +432,9 @@ export class ApplyEffectCommand {
     const track = this.audioStore.tracks.find(t => t.id === this.trackId)
     if (!track || !track.buffer) return
 
-    // Save previous buffer for undo
-    this.previousBuffer = this.cloneBuffer(track.buffer)
+    // applyEffectToTrack replaces track.buffer with a new reference,
+    // so holding the current one is enough for undo.
+    this.previousBuffer = track.buffer
 
     // Apply effect
     this.audioStore.applyEffectToTrack(this.trackId, this.effectName, this.params, this.selection)
@@ -506,20 +448,6 @@ export class ApplyEffectCommand {
     track.buffer = markRaw(this.previousBuffer)
     this.audioStore.engine.setTrackBuffer(this.trackId, this.previousBuffer)
     track.waveformData = markRaw(this.audioStore.generateWaveformData(this.previousBuffer))
-  }
-
-  cloneBuffer(buffer) {
-    const clone = this.audioStore.engine.audioContext.createBuffer(
-      buffer.numberOfChannels,
-      buffer.length,
-      buffer.sampleRate
-    )
-
-    for (let i = 0; i < buffer.numberOfChannels; i++) {
-      clone.getChannelData(i).set(buffer.getChannelData(i))
-    }
-
-    return clone
   }
 }
 
@@ -538,8 +466,8 @@ export class DeleteSelectionCommand {
     const track = this.audioStore.tracks.find(t => t.id === this.trackId)
     if (!track || !track.buffer || !this.selection) return
 
-    // Save previous buffer
-    this.previousBuffer = this.cloneBuffer(track.buffer)
+    // deleteSelection replaces track.buffer - hold a reference for undo.
+    this.previousBuffer = track.buffer
 
     // Delete selection
     this.audioStore.deleteSelection(this.trackId, this.selection)
@@ -554,20 +482,6 @@ export class DeleteSelectionCommand {
     track.waveformData = markRaw(this.audioStore.generateWaveformData(this.previousBuffer))
     track.duration = this.previousBuffer.duration
     this.audioStore.updateDuration()
-  }
-
-  cloneBuffer(buffer) {
-    const clone = this.audioStore.engine.audioContext.createBuffer(
-      buffer.numberOfChannels,
-      buffer.length,
-      buffer.sampleRate
-    )
-
-    for (let i = 0; i < buffer.numberOfChannels; i++) {
-      clone.getChannelData(i).set(buffer.getChannelData(i))
-    }
-
-    return clone
   }
 }
 
@@ -587,8 +501,8 @@ export class PasteCommand {
     const track = this.audioStore.tracks.find(t => t.id === this.trackId)
     if (!track || !this.clipboardBuffer) return
 
-    // Save previous buffer (may be null for empty track)
-    this.previousBuffer = track.buffer ? this.cloneBuffer(track.buffer) : null
+    // pasteAtPosition replaces track.buffer; a reference is enough for undo.
+    this.previousBuffer = track.buffer || null
     this.audioStore.pasteAtPosition(this.trackId, this.clipboardBuffer, this.position)
   }
 
@@ -609,19 +523,5 @@ export class PasteCommand {
       track.waveformData = []
     }
     this.audioStore.updateDuration()
-  }
-
-  cloneBuffer(buffer) {
-    const clone = this.audioStore.engine.audioContext.createBuffer(
-      buffer.numberOfChannels,
-      buffer.length,
-      buffer.sampleRate
-    )
-
-    for (let i = 0; i < buffer.numberOfChannels; i++) {
-      clone.getChannelData(i).set(buffer.getChannelData(i))
-    }
-
-    return clone
   }
 }

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -2,6 +2,7 @@
  * Command pattern for undo/redo functionality
  * Each command must implement execute() and undo() methods
  */
+import { markRaw } from 'vue'
 
 /**
  * Add clip to track
@@ -354,8 +355,8 @@ export class ApplyEffectToClipCommand {
       const clip = clipData.clip
       this.previousClipState = {
         ...clip,
-        buffer: this.cloneBuffer(clip.buffer),
-        waveformData: [...clip.waveformData]
+        buffer: markRaw(this.cloneBuffer(clip.buffer)),
+        waveformData: markRaw([...clip.waveformData])
       }
     }
 
@@ -375,11 +376,9 @@ export class ApplyEffectToClipCommand {
     // Restore previous clip state
     track.clips.splice(clipIndex, 1, {
       ...this.previousClipState,
-      _lastModified: Date.now()
+      buffer: markRaw(this.previousClipState.buffer),
+      waveformData: markRaw(this.previousClipState.waveformData)
     })
-
-    // Force reactivity
-    track.clips = [...track.clips]
 
     // Rebuild track buffer
     this.audioStore.updateTrackBufferFromClips(this.trackId)
@@ -504,9 +503,9 @@ export class ApplyEffectCommand {
     if (!track || !this.previousBuffer) return
 
     // Restore previous buffer
-    track.buffer = this.previousBuffer
+    track.buffer = markRaw(this.previousBuffer)
     this.audioStore.engine.setTrackBuffer(this.trackId, this.previousBuffer)
-    track.waveformData = this.audioStore.generateWaveformData(this.previousBuffer)
+    track.waveformData = markRaw(this.audioStore.generateWaveformData(this.previousBuffer))
   }
 
   cloneBuffer(buffer) {
@@ -550,9 +549,9 @@ export class DeleteSelectionCommand {
     const track = this.audioStore.tracks.find(t => t.id === this.trackId)
     if (!track || !this.previousBuffer) return
 
-    track.buffer = this.previousBuffer
+    track.buffer = markRaw(this.previousBuffer)
     this.audioStore.engine.setTrackBuffer(this.trackId, this.previousBuffer)
-    track.waveformData = this.audioStore.generateWaveformData(this.previousBuffer)
+    track.waveformData = markRaw(this.audioStore.generateWaveformData(this.previousBuffer))
     track.duration = this.previousBuffer.duration
     this.audioStore.updateDuration()
   }
@@ -599,9 +598,9 @@ export class PasteCommand {
 
     // Restore previous buffer (may be null)
     if (this.previousBuffer) {
-      track.buffer = this.previousBuffer
+      track.buffer = markRaw(this.previousBuffer)
       this.audioStore.engine.setTrackBuffer(this.trackId, this.previousBuffer)
-      track.waveformData = this.audioStore.generateWaveformData(this.previousBuffer)
+      track.waveformData = markRaw(this.audioStore.generateWaveformData(this.previousBuffer))
       track.duration = this.previousBuffer.duration
     } else {
       // Track was empty before, restore to empty

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -101,15 +101,10 @@ export class MoveClipCommand {
       clip.color = toTrack.color
       toTrack.clips.push(clip)
       toTrack.clips = [...toTrack.clips]
-
-      // Update both tracks
-      this.audioStore.updateTrackBufferFromClips(this.fromTrackId)
-      this.audioStore.updateTrackBufferFromClips(this.toTrackId)
     } else {
       // Just update position on same track
       clip.startTime = this.newStartTime
       fromTrack.clips = [...fromTrack.clips]
-      this.audioStore.updateTrackBufferFromClips(this.fromTrackId)
     }
 
     this.audioStore.updateDuration()
@@ -137,15 +132,10 @@ export class MoveClipCommand {
       clip.color = toTrack.color
       toTrack.clips.push(clip)
       toTrack.clips = [...toTrack.clips]
-
-      // Update both tracks
-      this.audioStore.updateTrackBufferFromClips(this.toTrackId)
-      this.audioStore.updateTrackBufferFromClips(this.fromTrackId)
     } else {
       // Just restore position on same track
       clip.startTime = this.oldStartTime
       fromTrack.clips = [...fromTrack.clips]
-      this.audioStore.updateTrackBufferFromClips(this.fromTrackId)
     }
 
     this.audioStore.updateDuration()
@@ -241,7 +231,6 @@ export class PasteClipCommand {
       if (clipIndex !== -1) {
         track.clips.splice(clipIndex, 1)
         track.clips = [...track.clips]
-        this.audioStore.updateTrackBufferFromClips(this.trackId)
         this.audioStore.updateDuration()
         console.log(`↩️ Removed pasted clip`)
       }
@@ -350,9 +339,7 @@ export class ApplyEffectToClipCommand {
       buffer: markRaw(this.previousClipState.buffer),
       waveformData: markRaw(this.previousClipState.waveformData)
     })
-
-    // Rebuild track buffer
-    this.audioStore.updateTrackBufferFromClips(this.trackId)
+    this.audioStore.updateDuration()
   }
 }
 

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -161,9 +161,12 @@ export class CutClipCommand {
 
     const { clip, trackId } = clipData
 
-    // Copy to clipboard
+    // Copy to clipboard (preserve the clip's buffer window so paste
+    // reproduces only the region the clip actually plays)
     this.audioStore.clipboard = {
       buffer: clip.buffer,
+      bufferOffset: clip.bufferOffset || 0,
+      bufferLength: clip.bufferLength ?? clip.buffer.length,
       duration: clip.duration,
       name: clip.name,
       color: clip.color
@@ -204,12 +207,16 @@ export class PasteClipCommand {
     // Save clipboard data
     this.clipboardData = { ...this.audioStore.clipboard }
 
-    // Add clip to track
+    // Add clip to track, preserving the original window if any
     const clip = this.audioStore.addClipToTrack(
       this.trackId,
       this.clipboardData.buffer,
       this.position,
-      this.clipboardData.name || 'Pasted Clip'
+      this.clipboardData.name || 'Pasted Clip',
+      {
+        bufferOffset: this.clipboardData.bufferOffset || 0,
+        bufferLength: this.clipboardData.bufferLength ?? this.clipboardData.buffer.length
+      }
     )
 
     if (clip) {

--- a/src/workers/autosaveWorker.js
+++ b/src/workers/autosaveWorker.js
@@ -1,0 +1,68 @@
+/**
+ * Autosave worker - encodes AudioBuffer channel data to a 16-bit PCM WAV
+ * blob off the main thread.
+ *
+ * Request:  { id, channels: Float32Array[], sampleRate, windowOffset?, windowLength? }
+ *   `channels` is transferred to the worker.
+ * Response: { id, type: 'done', wav: ArrayBuffer }  (wav is transferred back)
+ *           { id, type: 'error', error: string }
+ */
+
+function encodeWav(channels, sampleRate, windowOffset = 0, windowLength = null) {
+  const numberOfChannels = channels.length
+  const bitDepth = 16
+  const bytesPerSample = bitDepth / 8
+  const blockAlign = numberOfChannels * bytesPerSample
+
+  const firstChannelLen = channels[0]?.length ?? 0
+  const start = Math.max(0, windowOffset | 0)
+  const end = windowLength != null
+    ? Math.min(firstChannelLen, start + windowLength)
+    : firstChannelLen
+  const sampleCount = Math.max(0, end - start)
+
+  const dataLength = sampleCount * numberOfChannels * bytesPerSample
+  const buffer = new ArrayBuffer(44 + dataLength)
+  const view = new DataView(buffer)
+
+  function writeString(offset, string) {
+    for (let i = 0; i < string.length; i++) {
+      view.setUint8(offset + i, string.charCodeAt(i))
+    }
+  }
+
+  writeString(0, 'RIFF')
+  view.setUint32(4, 36 + dataLength, true)
+  writeString(8, 'WAVE')
+  writeString(12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true) // PCM
+  view.setUint16(22, numberOfChannels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, sampleRate * blockAlign, true)
+  view.setUint16(32, blockAlign, true)
+  view.setUint16(34, bitDepth, true)
+  writeString(36, 'data')
+  view.setUint32(40, dataLength, true)
+
+  let offset = 44
+  for (let i = 0; i < sampleCount; i++) {
+    for (let ch = 0; ch < numberOfChannels; ch++) {
+      const sample = Math.max(-1, Math.min(1, channels[ch][start + i]))
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7FFF, true)
+      offset += 2
+    }
+  }
+
+  return buffer
+}
+
+self.onmessage = (event) => {
+  const { id, channels, sampleRate, windowOffset, windowLength } = event.data
+  try {
+    const wav = encodeWav(channels, sampleRate, windowOffset, windowLength)
+    self.postMessage({ id, type: 'done', wav }, [wav])
+  } catch (error) {
+    self.postMessage({ id, type: 'error', error: String(error.message || error) })
+  }
+}

--- a/src/workers/effectsWorker.js
+++ b/src/workers/effectsWorker.js
@@ -1,0 +1,250 @@
+/**
+ * Effects Web Worker
+ *
+ * Runs audio effects off the main thread so the UI stays responsive while
+ * processing long clips. Receives `{ id, effectName, params, channelBuffers,
+ * sampleRate }` and posts back `{ id, processedBuffers }` using transferable
+ * objects for zero-copy.
+ *
+ * The effect implementations below are ports of the main-thread versions in
+ * AdvancedEffects.js / WasmBridge.js - kept simple so the worker is
+ * self-contained and doesn't need a build step.
+ */
+
+// ---------------------------------------------------------------------------
+// Effect implementations (main-thread equivalents are in AdvancedEffects.js
+// and WasmBridge.js; kept in sync with those).
+// ---------------------------------------------------------------------------
+
+function amplify(input, factor) {
+  const output = new Float32Array(input.length)
+  for (let i = 0; i < input.length; i++) {
+    output[i] = Math.max(-1, Math.min(1, input[i] * factor))
+  }
+  return output
+}
+
+function normalize(input, targetPeak = 1.0) {
+  let peak = 0
+  for (let i = 0; i < input.length; i++) {
+    const v = Math.abs(input[i])
+    if (v > peak) peak = v
+  }
+  if (peak < 0.0001) return new Float32Array(input)
+  const factor = targetPeak / peak
+  const output = new Float32Array(input.length)
+  for (let i = 0; i < input.length; i++) output[i] = input[i] * factor
+  return output
+}
+
+function fadeIn(input, fadeSamples) {
+  const output = new Float32Array(input)
+  const actual = Math.min(fadeSamples, input.length)
+  for (let i = 0; i < actual; i++) output[i] *= i / actual
+  return output
+}
+
+function fadeOut(input, fadeSamples) {
+  const output = new Float32Array(input)
+  const actual = Math.min(fadeSamples, input.length)
+  const start = input.length - actual
+  for (let i = 0; i < actual; i++) output[start + i] *= 1 - i / actual
+  return output
+}
+
+function reverse(input) {
+  const output = new Float32Array(input.length)
+  for (let i = 0; i < input.length; i++) output[i] = input[input.length - 1 - i]
+  return output
+}
+
+function lowPassFilter(input, cutoffFreq, sampleRate) {
+  const output = new Float32Array(input.length)
+  const rc = 1.0 / (cutoffFreq * 2 * Math.PI)
+  const dt = 1.0 / sampleRate
+  const alpha = dt / (rc + dt)
+  output[0] = input[0]
+  for (let i = 1; i < input.length; i++) {
+    output[i] = output[i - 1] + alpha * (input[i] - output[i - 1])
+  }
+  return output
+}
+
+function highPassFilter(input, cutoffFreq, sampleRate) {
+  const output = new Float32Array(input.length)
+  const rc = 1.0 / (cutoffFreq * 2 * Math.PI)
+  const dt = 1.0 / sampleRate
+  const alpha = rc / (rc + dt)
+  output[0] = input[0]
+  for (let i = 1; i < input.length; i++) {
+    output[i] = alpha * (output[i - 1] + input[i] - input[i - 1])
+  }
+  return output
+}
+
+function compress(input, threshold, ratio, attackTime, releaseTime, sampleRate) {
+  const output = new Float32Array(input.length)
+  let env = 0
+  const attackCoef = Math.exp(-1 / (sampleRate * attackTime))
+  const releaseCoef = Math.exp(-1 / (sampleRate * releaseTime))
+  for (let i = 0; i < input.length; i++) {
+    const level = Math.abs(input[i])
+    env = level > env
+      ? attackCoef * env + (1 - attackCoef) * level
+      : releaseCoef * env + (1 - releaseCoef) * level
+    let gain = 1
+    if (env > threshold) {
+      const excess = env - threshold
+      gain = threshold / env + (excess / env) / ratio
+    }
+    output[i] = input[i] * gain
+  }
+  return output
+}
+
+function reverb(input, roomSize = 0.5, damping = 0.5, wetLevel = 0.3, dryLevel = 0.7) {
+  if (!input || input.length === 0) return new Float32Array(0)
+  roomSize = Math.max(0, Math.min(1, roomSize))
+  damping = Math.max(0, Math.min(1, damping))
+  wetLevel = Math.max(0, Math.min(1, wetLevel))
+  dryLevel = Math.max(0, Math.min(1, dryLevel))
+
+  const output = new Float32Array(input.length)
+  const combDelays = [1557, 1617, 1491, 1422, 1277, 1356, 1188, 1116].map(d =>
+    Math.floor(d * (0.5 + roomSize * 0.5))
+  )
+  const allpassDelays = [225, 556, 441, 341]
+  const combBuffers = combDelays.map(d => new Float32Array(d))
+  const combIndices = combDelays.map(() => 0)
+  const allpassBuffers = allpassDelays.map(d => new Float32Array(d))
+  const allpassIndices = allpassDelays.map(() => 0)
+  const combFeedback = 0.65 * (1 - damping * 0.5)
+
+  let peak = 0
+  for (let i = 0; i < input.length; i++) {
+    let sample = Math.max(-1, Math.min(1, input[i]))
+    let combOut = 0
+    for (let j = 0; j < combBuffers.length; j++) {
+      const delay = combDelays[j]
+      const buffer = combBuffers[j]
+      const idx = combIndices[j]
+      const delayed = buffer[idx]
+      combOut += delayed
+      buffer[idx] = sample + delayed * combFeedback
+      combIndices[j] = (idx + 1) % delay
+    }
+    combOut /= combBuffers.length
+
+    let allpassOut = combOut
+    for (let j = 0; j < allpassBuffers.length; j++) {
+      const delay = allpassDelays[j]
+      const buffer = allpassBuffers[j]
+      const idx = allpassIndices[j]
+      const delayed = buffer[idx]
+      const ff = allpassOut * -0.5
+      allpassOut = Math.max(-1, Math.min(1, (delayed + ff) * 0.5))
+      buffer[idx] = allpassOut + delayed * 0.5
+      allpassIndices[j] = (idx + 1) % delay
+    }
+
+    let v = sample * dryLevel + allpassOut * wetLevel
+    v = Math.max(-1, Math.min(1, v))
+    output[i] = v
+    const abs = v < 0 ? -v : v
+    if (abs > peak) peak = abs
+  }
+
+  if (peak > 0.95) {
+    const norm = 0.95 / peak
+    for (let i = 0; i < output.length; i++) output[i] *= norm
+  }
+
+  return output
+}
+
+function equalizer(input, bands, sampleRate) {
+  const frequencies = [31, 62, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+  let output = new Float32Array(input)
+  for (const freq of frequencies) {
+    const gainDB = bands[freq] || 0
+    if (Math.abs(gainDB) < 0.1) continue
+    const gain = Math.pow(10, gainDB / 20)
+    const Q = 1.0
+    const w0 = 2 * Math.PI * freq / sampleRate
+    const alpha = Math.sin(w0) / (2 * Q)
+    const A = gain
+    const b0 = 1 + alpha * A
+    const b1 = -2 * Math.cos(w0)
+    const b2 = 1 - alpha * A
+    const a0 = 1 + alpha / A
+    const a1 = -2 * Math.cos(w0)
+    const a2 = 1 - alpha / A
+    const temp = new Float32Array(output.length)
+    temp[0] = output[0]; temp[1] = output[1]
+    for (let i = 2; i < output.length; i++) {
+      temp[i] = (b0 / a0) * output[i] + (b1 / a0) * output[i - 1] + (b2 / a0) * output[i - 2]
+              - (a1 / a0) * temp[i - 1] - (a2 / a0) * temp[i - 2]
+    }
+    output = temp
+  }
+  return output
+}
+
+function changePitch(input, semitones) {
+  const ratio = Math.pow(2, semitones / 12)
+  const outputLength = Math.floor(input.length / ratio)
+  const output = new Float32Array(outputLength)
+  for (let i = 0; i < outputLength; i++) {
+    const pos = i * ratio
+    const index = Math.floor(pos)
+    const frac = pos - index
+    if (index + 1 < input.length) {
+      output[i] = input[index] * (1 - frac) + input[index + 1] * frac
+    } else if (index < input.length) {
+      output[i] = input[index]
+    }
+  }
+  return output
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+function processChannel(effectName, params, channelData, sampleRate) {
+  switch (effectName) {
+    case 'amplify': return amplify(channelData, params.factor)
+    case 'normalize': return normalize(channelData, params.targetPeak)
+    case 'fadeIn': return fadeIn(channelData, params.samples)
+    case 'fadeOut': return fadeOut(channelData, params.samples)
+    case 'reverse': return reverse(channelData)
+    case 'lowPass': return lowPassFilter(channelData, params.cutoff, sampleRate)
+    case 'highPass': return highPassFilter(channelData, params.cutoff, sampleRate)
+    case 'compress': return compress(
+      channelData, params.threshold, params.ratio, params.attack, params.release, sampleRate)
+    case 'reverb': return reverb(
+      channelData, params.roomSize, params.damping, params.wetLevel, params.dryLevel)
+    case 'equalizer': return equalizer(channelData, params.bands, sampleRate)
+    case 'pitch': return changePitch(channelData, params.semitones)
+    default: throw new Error(`Unknown effect: ${effectName}`)
+  }
+}
+
+self.onmessage = (event) => {
+  const { id, effectName, params, channelBuffers, sampleRate } = event.data
+  try {
+    const processedBuffers = []
+    const transfers = []
+    for (let i = 0; i < channelBuffers.length; i++) {
+      const ch = channelBuffers[i]
+      const processed = processChannel(effectName, params, ch, sampleRate)
+      const percent = Math.round(((i + 1) / channelBuffers.length) * 100)
+      self.postMessage({ id, type: 'progress', percent })
+      processedBuffers.push(processed)
+      transfers.push(processed.buffer)
+    }
+    self.postMessage({ id, type: 'done', processedBuffers }, transfers)
+  } catch (error) {
+    self.postMessage({ id, type: 'error', error: String(error.message || error) })
+  }
+}


### PR DESCRIPTION
## Summary

This PR refactors the audio engine from a track-buffer-based architecture to a clip-based system. Instead of pre-mixing clips into single track buffers, clips are now scheduled individually during playback and rendering. This eliminates the need to rebuild track buffers on every edit and enables more efficient memory usage and real-time responsiveness.

## Key Changes

### Core Architecture
- **Clip-based playback**: Replaced `playTrack()` with `playTrackClips()` that schedules each clip as its own `BufferSource` at its `startTime`, avoiding pre-mixing overhead
- **Clip windowing**: Clips can now reference a window of their parent buffer via `bufferOffset` and `bufferLength` (in samples), allowing split clips to share buffers without copying audio
- **Offline rendering for export**: Introduced `computeMixedBuffer()` and `renderTracksOffline()` to mix clips only during export via `OfflineAudioContext`, never during editing
- **Removed track buffers**: Eliminated the single-buffer-per-track model; tracks now only store clip arrays

### Waveform Visualization
- **Per-clip waveforms**: Added `getOrGenerateClipWaveform()` to cache waveform data per clip with window awareness
- **Clip-aware generation**: Updated `generateWaveformData()` to accept `bufferOffset` and `bufferLength` parameters
- **Virtualized rendering**: Modified `AudioClip.vue` to use `IntersectionObserver` for viewport-based canvas painting, reducing off-screen rendering overhead

### Worker Threads
- **Effects worker**: New `EffectsWorkerClient` and `effectsWorker.js` run audio effects off the main thread with progress reporting
- **Autosave worker**: New `autosaveWorker.js` encodes clip WAV data without blocking the UI
- **Debounced autosave**: Changed from interval-based to debounce-based (10s) with per-clip fingerprinting to skip unchanged clips

### Command & State Management
- **Simplified undo/redo**: Removed buffer cloning in commands since `AudioBuffer` is immutable; holding references is safe
- **Clipboard preservation**: Updated clipboard to store `bufferOffset` and `bufferLength` so pasted clips preserve their window
- **Duration calculation**: Rewrote `longestTrackDuration` and `updateDuration()` to compute from clip positions rather than track buffers

### UI Updates
- **Track component**: Removed waveform canvas drawing; clips now render their own waveforms
- **Selection styling**: Fixed to use project duration instead of track duration for correct positioning
- **Effect panel**: Added progress bar for worker-based effect processing

## Implementation Details

- **markRaw() usage**: Applied to `AudioBuffer` references and worker instances to prevent unnecessary Vue reactivity overhead
- **Transferable objects**: Worker communication uses `ArrayBuffer` transfers for zero-copy channel data
- **Clip identity**: Clips maintain `_waveformBufferRef`, `_waveformOffset`, and `_waveformLength` to detect cache invalidation
- **Backward compatibility**: Kept legacy `playTrack()` and `play()` methods as no-ops to avoid breaking existing code
- **Sample-accurate scheduling**: Clip playback accounts for `bufferOffset` and partial playback when starting mid-clip

https://claude.ai/code/session_01G9j8anu26BmJUoRtRpRs12